### PR TITLE
Adding locktime to payment methods

### DIFF
--- a/src/mgmt/item.mgmt.ts
+++ b/src/mgmt/item.mgmt.ts
@@ -84,6 +84,7 @@ export function createIbTxHalf(
     receiverExpectation: IDruidExpectation,
     excessAddress: string,
     allKeypairs: Map<string, IKeypair>,
+    locktime: number,
 ): IResult<ICreateTxPayload> {
     // Gather `TxIn` values
     const txIns = getInputsForTx(receiverExpectation.asset, fetchBalanceResponse, allKeypairs);
@@ -105,5 +106,6 @@ export function createIbTxHalf(
         excessAddress,
         druidInfo,
         txIns.value,
+        locktime,
     );
 }

--- a/src/mgmt/script.mgmt.ts
+++ b/src/mgmt/script.mgmt.ts
@@ -195,8 +195,6 @@ export function updateSignatures(
                 transaction.createTx.outputs,
             );
 
-            console.log('Signable data: ', signableData);
-
             if (signableData === null) return err(IErrorInternal.UnableToConstructSignature);
             const signature = constructSignature(getStringBytes(signableData), keyPair.secretKey);
 

--- a/src/mgmt/script.mgmt.ts
+++ b/src/mgmt/script.mgmt.ts
@@ -195,6 +195,8 @@ export function updateSignatures(
                 transaction.createTx.outputs,
             );
 
+            console.log('Signable data: ', signableData);
+
             if (signableData === null) return err(IErrorInternal.UnableToConstructSignature);
             const signature = constructSignature(getStringBytes(signableData), keyPair.secretKey);
 

--- a/src/mgmt/tx.mgmt.ts
+++ b/src/mgmt/tx.mgmt.ts
@@ -264,7 +264,14 @@ export function createPaymentTx(
     const txIns = getInputsForTx(paymentAsset, fetchBalanceResponse, allKeypairs);
     if (txIns.isErr()) return err(txIns.error);
 
-    const transaction = createTx(paymentAddress, paymentAsset, excessAddress, null, txIns.value, locktime);
+    const transaction = createTx(
+        paymentAddress,
+        paymentAsset,
+        excessAddress,
+        null,
+        txIns.value,
+        locktime,
+    );
     if (transaction.isErr()) return err(transaction.error);
 
     // Update signatures

--- a/src/mgmt/tx.mgmt.ts
+++ b/src/mgmt/tx.mgmt.ts
@@ -189,6 +189,7 @@ export function createTx(
     excessAddress: string,
     druidInfo: IDruidValues | null,
     txIns: IGetInputsResult,
+    locktime: number,
 ): IResult<ICreateTxPayload> {
     // Inputs obtained for payment from fetching the balance from the network
     // TODO: Do something with `depletedAddresses`
@@ -203,7 +204,7 @@ export function createTx(
     const outputs: ITxOut[] = [
         {
             value: paymentAsset,
-            locktime: 0,
+            locktime,
             script_public_key: paymentAddress,
         },
     ];
@@ -257,12 +258,13 @@ export function createPaymentTx(
     excessAddress: string,
     fetchBalanceResponse: IFetchBalanceResponse,
     allKeypairs: Map<string, IKeypair>,
+    locktime: number,
 ): IResult<ICreateTxPayload> {
     // Gather inputs for the transaction
     const txIns = getInputsForTx(paymentAsset, fetchBalanceResponse, allKeypairs);
     if (txIns.isErr()) return err(txIns.error);
 
-    const transaction = createTx(paymentAddress, paymentAsset, excessAddress, null, txIns.value);
+    const transaction = createTx(paymentAddress, paymentAsset, excessAddress, null, txIns.value, locktime);
     if (transaction.isErr()) return err(transaction.error);
 
     // Update signatures

--- a/src/services/wallet.service.ts
+++ b/src/services/wallet.service.ts
@@ -549,6 +549,7 @@ export class Wallet {
         receivingAsset: IAssetItem | IAssetToken,
         allKeypairs: IKeypairEncrypted[],
         receiveAddress: IKeypairEncrypted,
+        locktime = 0,
     ): Promise<IClientResponse> {
         try {
             if (!this.mempoolHost || !this.keyMgmt || !this.mempoolRoutesPoW)
@@ -590,6 +591,7 @@ export class Wallet {
                     receiverExpectation,
                     senderKeypair.address,
                     keyPairMap,
+                    locktime,
                 ),
             );
 
@@ -1059,7 +1061,7 @@ export class Wallet {
         paymentAsset: IAssetToken | IAssetItem,
         allKeypairs: IKeypairEncrypted[],
         excessKeypair: IKeypairEncrypted,
-        locktime: number = 0,
+        locktime = 0,
     ) {
         try {
             if (!this.mempoolHost || !this.keyMgmt || !this.mempoolRoutesPoW)
@@ -1084,7 +1086,7 @@ export class Wallet {
                     excessKeypair.address,
                     balance.content.fetchBalanceResponse,
                     keyPairMap,
-                    locktime
+                    locktime,
                 ),
             );
 
@@ -1154,6 +1156,7 @@ export class Wallet {
         pendingResponse: IResponseIntercom<IPendingIbTxDetails>,
         status: 'accepted' | 'rejected',
         allKeypairs: IKeypairEncrypted[],
+        locktime = 0,
     ): Promise<IClientResponse> {
         try {
             if (!this.mempoolHost || !this.keyMgmt || !this.mempoolRoutesPoW)
@@ -1200,6 +1203,7 @@ export class Wallet {
                         txInfo.senderExpectation, // What the other party can expect from us
                         receiverKeypair.address,
                         keyPairMap,
+                        locktime,
                     ),
                 );
 

--- a/src/services/wallet.service.ts
+++ b/src/services/wallet.service.ts
@@ -1059,6 +1059,7 @@ export class Wallet {
         paymentAsset: IAssetToken | IAssetItem,
         allKeypairs: IKeypairEncrypted[],
         excessKeypair: IKeypairEncrypted,
+        locktime: number = 0,
     ) {
         try {
             if (!this.mempoolHost || !this.keyMgmt || !this.mempoolRoutesPoW)
@@ -1083,6 +1084,7 @@ export class Wallet {
                     excessKeypair.address,
                     balance.content.fetchBalanceResponse,
                     keyPairMap,
+                    locktime
                 ),
             );
 

--- a/src/services/wallet.service.ts
+++ b/src/services/wallet.service.ts
@@ -502,9 +502,10 @@ export class Wallet {
         paymentAmount: number,
         allKeypairs: IKeypairEncrypted[],
         excessKeypair: IKeypairEncrypted,
+        locktime: number = 0,
     ): Promise<IClientResponse> {
         const paymentAsset = initIAssetToken({ Token: paymentAmount });
-        return this.makePayment(paymentAddress, paymentAsset, allKeypairs, excessKeypair);
+        return this.makePayment(paymentAddress, paymentAsset, allKeypairs, excessKeypair, locktime);
     }
 
     /**
@@ -525,11 +526,12 @@ export class Wallet {
         allKeypairs: IKeypairEncrypted[],
         excessKeypair: IKeypairEncrypted,
         metadata: string | null = null,
+        locktime: number = 0,
     ): Promise<IClientResponse> {
         const paymentAsset = initIAssetItem({
             Item: { amount: paymentAmount, genesis_hash: genesisHash, metadata },
         });
-        return this.makePayment(paymentAddress, paymentAsset, allKeypairs, excessKeypair);
+        return this.makePayment(paymentAddress, paymentAsset, allKeypairs, excessKeypair, locktime);
     }
 
     /**
@@ -1090,9 +1092,6 @@ export class Wallet {
                 ),
             );
 
-            console.log('paymentBody', paymentBody.createTx);
-            console.log('paymentBody', JSON.stringify(paymentBody.createTx));
-
             const { usedAddresses } = paymentBody;
 
             // Generate the needed headers
@@ -1102,7 +1101,6 @@ export class Wallet {
             );
 
             // Send transaction to mempool for processing
-            console.log('Hi');
             return await axios
                 .post<INetworkResponse>(
                     `${this.mempoolHost}${IAPIRoute.CreateTransactions}`,

--- a/src/tests/__tests__/item.mgmt.test.ts
+++ b/src/tests/__tests__/item.mgmt.test.ts
@@ -109,6 +109,7 @@ test('create transaction for the SEND portion of a item-based payment', () => {
         }),
         'excess_address',
         keyPairMap,
+        0,
     );
 
     if (createTransaction.isOk()) {
@@ -261,6 +262,7 @@ test('create transaction for the RECEIVE portion of a item-based payment', () =>
         }),
         'excess_address',
         keyPairMap,
+        0,
     );
 
     if (createTransaction.isOk()) {

--- a/src/tests/__tests__/tx.mgmt.test.ts
+++ b/src/tests/__tests__/tx.mgmt.test.ts
@@ -7,6 +7,7 @@ import { initIAssetToken } from '../../utils';
 
 test('create transaction for a token amount', () => {
     const keyPairMap = new Map<string, IKeypair>();
+    const LOCKTIME = 100;
     for (const addr of Object.keys(ADDRESS_LIST_TEST)) {
         keyPairMap.set(addr, {
             address: addr,
@@ -25,6 +26,7 @@ test('create transaction for a token amount', () => {
         'excess_address',
         FETCH_BALANCE_RESPONSE_TEST,
         keyPairMap,
+        LOCKTIME,
     );
 
     // Transaction created successfully
@@ -51,7 +53,7 @@ test('create transaction for a token amount', () => {
             expect(txOuts).toStrictEqual([
                 {
                     value: { Token: 1050 } /* Amount payed */,
-                    locktime: 0,
+                    locktime: LOCKTIME,
                     script_public_key: 'payment_address',
                 },
                 {
@@ -90,9 +92,9 @@ test('create transaction for a token amount', () => {
                 {
                     Pay2PkH: {
                         signable_data:
-                            '2dd512e5703df4ff16361d7a51762c266b1fd4e7cc15b4cfa25c2799b709d71a',
+                            '5604f8ef313423f0496c1b219ff10f2a575d8c8a9e0d67f2f3a084c1cece72f6',
                         signature:
-                            '5d67e4b8d694b14ef003ebe5625d76f509e57f6ead4b13162066bff2f9c0a1bfea8ce64928c2e66e05bda42fd12372b2862f4f1da94e1932c36718290fd7e408',
+                            'ddf8bea9b07b154f73415c7abdba3f46e69de9cc1e51c50f22f3025d8ae491ed74a79528ae8da3202360d6c91b4329b2f53b8822e0bed3c03b3ba8dee1e0af00',
                         public_key:
                             '5e6d463ec66d7999769fa4de56f690dfb62e685b97032f5926b0cb6c93ba83c6',
                         address_version: null,
@@ -101,9 +103,9 @@ test('create transaction for a token amount', () => {
                 {
                     Pay2PkH: {
                         signable_data:
-                            '86f2677098e5daf02cf82681334baf4e2fae03cc7d4f895972f904de66b1567c',
+                            'f4a54008332abcf5041a99be9bd640b6cf95226b5724311e6d2c4b2f58052579',
                         signature:
-                            'a4882091ecbdc4cc8a74203a8c8c78503fe475fc949b6a6188e17ee90074f584bd31b7481a32428553af0613b96e2fd3aa68d179d5677d20054125ac1383ec0f',
+                            '3f5f8d17032f3b52a613e839fdaff37f116d36a252ccf22eab8eecb7b7fae8f56c9fe490008ed8eb25f14fee61dd26ce1b860d780eb02c0ef4da115d86d6c708',
                         public_key:
                             '58272ba93c1e79df280d4c417de47dbf6a7e330ba52793d7baa8e00ae5c34e59',
                         address_version: null,
@@ -112,9 +114,9 @@ test('create transaction for a token amount', () => {
                 {
                     Pay2PkH: {
                         signable_data:
-                            '1623899f51915544ca0ca6a53fdba77a846c85e0776d13fd208753c0150ac65d',
+                            'a516249b5a0cf36e9328b54bd786d8a94107c9e4ede19df9257c43d142f76e1f',
                         signature:
-                            '77a215f3a0d96b96fb92fa0b17725365fd04d1c36a159e599fdb8d0338d6e38333d74ebb4aa952ee4942a0dc97612101172ce6f9ff63a546011e6f38dcbbca09',
+                            'd9700f15cd22b3de130904335051d2469af3ae8a40db06e12b4a0e6967b24254ac0a767d410f13a8da8565b04f7324ff7e0fc5006018a792c6dfcd567fcd610c',
                         public_key:
                             'efa9dcba0f3282b3ed4a6aa1ccdb169d6685a30d7b2af7a2171a5682f3112359',
                         address_version: null,
@@ -135,6 +137,7 @@ test('create transaction for a token amount', () => {
         'excess_address',
         FETCH_BALANCE_RESPONSE_TEST,
         keyPairMap,
+        0,
     );
     expect(createTransactionFailure._unsafeUnwrapErr()).toStrictEqual(
         IErrorInternal.InsufficientFunds,


### PR DESCRIPTION
## Description
Adds `locktime` parameter to payment methods for both tokens and items.

## TODO BEFORE MERGING

- The methods now take too many arguments; it would be best to restructure these
- Update documentation

## Changelog

- Adds `locktime` parameter to all payment methods for both tokens and items.

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.